### PR TITLE
[fix] bug fixes and refactors

### DIFF
--- a/frontend/src/contexts/BlogContext.tsx
+++ b/frontend/src/contexts/BlogContext.tsx
@@ -16,15 +16,13 @@ function useBlogContextProps(): BlogValue {
     const [selectedBlog, setSelectedBlog] = useState<Blog['id'] | null>(null);
     const handleBlogChange = (selectedBlog: Blog['id']) => setSelectedBlog(selectedBlog);
 
-    const { loading, data, error } = useFetchData(
-        fetchBlogs, [], []
+    const updateData = (data: Blog[]) => {
+        setBlogs(data);
+        setSelectedBlog(data[0]?.id);
+    }
+    const { loading, error } = useFetchData(
+        fetchBlogs, [], [], updateData
     );
-    useEffect(() => {
-        if (!loading && data) {
-            setBlogs(data);
-            setSelectedBlog(data[0]?.id);
-        }
-    }, [loading, data]);
 
     return {
         blogs,

--- a/frontend/src/loaders/useFetchData.ts
+++ b/frontend/src/loaders/useFetchData.ts
@@ -22,17 +22,17 @@ type Dependencies = any[];
 // Define a type for the return value of useFetchData hook
 type UseFetchDataResult<T> = {
     loading: boolean;
-    data: T | null;
+    data?: T | null;
     error: Error | null;
 };
 
 export function useFetchData<T>(
     fetchFunction: FetchFunction<T>,
     fetchParams: FetchParams,
-    dependencies: Dependencies
+    dependencies: Dependencies,
+    updateData: (data: T) => void // used to update the page if it's ready
 ): UseFetchDataResult<T> {
     const [loading, setLoading] = useState(false);
-    const [data, setData] = useState<T | null>(null);
     const [error, setError] = useState<Error | null>(null);
 
     useEffect(() => {
@@ -41,7 +41,7 @@ export function useFetchData<T>(
             setLoading(true);
             fetchFunction(...fetchParams)
                 .then((responseData: T) => {
-                    setData(responseData);
+                    updateData(responseData);
                 })
                 .catch((error) => {
                     setError(error);
@@ -52,5 +52,5 @@ export function useFetchData<T>(
         }
     }, dependencies);
 
-    return { loading, data, error };
+    return { loading, error };
 }

--- a/frontend/src/pages/EditPost.tsx
+++ b/frontend/src/pages/EditPost.tsx
@@ -27,15 +27,13 @@ export default function Component() {
     const { selectedBlog: blogId, isBlogsLoading, error } = useContext(BlogContext);
     const [pageError, setPageError] = useState(null);
 
-    const { loading, data, error: postsError } = useFetchData(
-        fetchPost, [blogId, id], [blogId, id]
+    const updateData = (data: { title: string, content: string }) => {
+        setTitle(data.title);
+        setContent(data.content);
+    }
+    const { loading, error: postsError } = useFetchData(
+        fetchPost, [blogId, id], [blogId, id], updateData
     );
-    React.useEffect(() => {
-        if (!loading && data) {
-            setTitle(data.title);
-            setContent(data.content);
-        }
-    }, [loading, data]);
 
     const onSubmit = () => {
         if (!blogId) {

--- a/frontend/src/pages/PostsList.tsx
+++ b/frontend/src/pages/PostsList.tsx
@@ -13,27 +13,30 @@ import Typography from '@mui/joy/Typography';
 import { useFetchData } from "../loaders/useFetchData";
 
 export default function Component() {
+    const { selectedBlog: blogId } = useContext(BlogContext);
+    // fixes a bug where the set does not reset with a changed blog ID
+    return <PostList key={blogId} />
+}
+
+function PostList() {
     const [posts, setPosts] = React.useState<Post[]>([]);
     const [currentPageToken, setCurrentPageToken] = React.useState<PostListResponse['nextPageToken']>(undefined);
     const [nextPageToken, setNextPageToken] = React.useState<PostListResponse['nextPageToken']>(undefined);
     const { isBlogsLoading, error, blogs, selectedBlog: blogId } = useContext(BlogContext);
     const history = useHistory();
-    const { loading: isPostsLoading, data, error: postsError } = useFetchData(
-        fetchPosts, [blogId, nextPageToken], [blogId, nextPageToken]
+    const updateData = (data: PostListResponse) => {
+        setPosts(posts => [...posts, ...data.items]);
+        setCurrentPageToken(data.nextPageToken);
+    };
+    const { loading: isPostsLoading, error: postsError } = useFetchData(
+        fetchPosts, [blogId, nextPageToken], [blogId, nextPageToken], updateData
     );
-    useEffect(() => {
-        if (!isPostsLoading && data) {
-            setPosts([...posts, ...data.items]);
-            setCurrentPageToken(data.nextPageToken);
-        }
-    }, [isPostsLoading, data]);
 
     const handleDelete = (id: Post['id']) => {
         if (blogId) {
             deletePost(blogId, id)
                 .then(() => setPosts(posts.filter((post) => post.id !== id)))
         }
-
     };
 
     const createPost = () => history.push(Paths.CreatePost);

--- a/frontend/src/pages/ShowPost.tsx
+++ b/frontend/src/pages/ShowPost.tsx
@@ -17,16 +17,15 @@ export default function Component() {
     const { id } = useParams<{ id: string }>();
     const { selectedBlog: blogId } = useContext(BlogContext);
     const downloadPost = async () => { };
+    const updateData = (data: { title: string, content: string }) => {
+        setTitle(data.title);
+        setContent(data.content);
+    }
 
-    const { loading, data, error } = useFetchData(
-        fetchPost, [blogId, id], [blogId, id]
+    const { loading, error } = useFetchData(
+        fetchPost, [blogId, id], [blogId, id], updateData
     );
-    React.useEffect(() => {
-        if (!loading && data) {
-            setTitle(data.title);
-            setContent(data.content);
-        }
-    }, [loading, data]);
+
     return <Sheet
         isLoading={loading}
         error={error}


### PR DESCRIPTION
# Changes made

- Allows each page to use a function to update the page after the query returns with data.
Rationale: Previously, changes to the page was updated via a `useEffect` function, which triggers unnecessary re-renders. Additional state guarding logic was added to ensure that the effect was not triggered unnecessarily (only after the data query returned with data)

- Fixes a bug where the PostLists does not reset its props with a changed blog IDs (refer to: https://react.dev/learn/you-might-not-need-an-effect#resetting-all-state-when-a-prop-changes)
Rationale: Previously the PostList did not reset when the blog ID changes. This caused blogs to be rendered with posts from different blogs, and caused query errors as the page tokens could have belonged to different blogs.